### PR TITLE
🤖 Add docs configuration

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -1,0 +1,32 @@
+{
+  "docs": [
+    {
+      "uuid": "839ebe8b-b51d-480f-ae90-f43676977ee0",
+      "slug": "installation",
+      "path": "docs/INSTALLATION.md",
+      "title": "Installing Red locally",
+      "blurb": "Learn how to install Red locally to solve Exercism's exercises on your own machine"
+    },
+    {
+      "uuid": "cacc6bbb-73fc-472c-bc6c-49818f583658",
+      "slug": "learning",
+      "path": "docs/LEARNING.md",
+      "title": "How to learn Red",
+      "blurb": "An overview of how to get started from scratch with Red"
+    },
+    {
+      "uuid": "f2a5bc06-eb5e-4431-b6a6-aaa0665837e1",
+      "slug": "tests",
+      "path": "docs/TESTS.md",
+      "title": "Testing on the Red track",
+      "blurb": "Learn how to test your Red exercises on Exercism"
+    },
+    {
+      "uuid": "365432ca-6ac4-402d-856e-9611b71fda4c",
+      "slug": "resources",
+      "path": "docs/RESOURCES.md",
+      "title": "Useful Red resources",
+      "blurb": "A collection of useful resources to help you master Red"
+    }
+  ]
+}


### PR DESCRIPTION
To allow the v3 website to display the track's documentation, we're introducing a `docs/config.json` file, which contains information needed for rendering.

This commit adds the `docs/config.json` file. We will merge this PR shortly. For now, **please don't edit its contents**. We will follow up with a PR for CI, and with an issue linking you to the spec for this file once it's written up. Once that's all done, you will then be free to edit this config as normal 🙂

## Tracking

https://github.com/exercism/v3-launch/issues/25
