### PR TITLE
🤖 Add .meta/config.json file for concepts

### DIFF
--- a/concepts/basics/.meta/config.json
+++ b/concepts/basics/.meta/config.json
@@ -1,0 +1,5 @@
+{
+  "blurb": "General info about writing programs in Red.",
+  "authors": [],
+  "contributors": []
+}

--- a/concepts/functions/.meta/config.json
+++ b/concepts/functions/.meta/config.json
@@ -1,0 +1,5 @@
+{
+  "blurb": "Functions usually do something useful. And they usually return a value.",
+  "authors": [],
+  "contributors": []
+}

--- a/concepts/script/.meta/config.json
+++ b/concepts/script/.meta/config.json
@@ -1,0 +1,5 @@
+{
+  "blurb": "Script is set of instructions beginning with a header. It can be read from file.",
+  "authors": [],
+  "contributors": []
+}

--- a/concepts/strings/.meta/config.json
+++ b/concepts/strings/.meta/config.json
@@ -1,0 +1,5 @@
+{
+  "blurb": "Strings are values of type string!. They usually represent textual data.",
+  "authors": [],
+  "contributors": []
+}

--- a/config.json
+++ b/config.json
@@ -1,6 +1,5 @@
 {
   "version": 3,
-
   "language": "Red",
   "slug": "red",
   "active": false,
@@ -19,25 +18,21 @@
     {
       "slug": "basics",
       "name": "Basics",
-      "blurb": "General info about writing programs in Red.",
       "uuid": "726350c1-59c1-4ae6-8c72-a1e49ce7a0ed"
     },
     {
       "slug": "script",
       "name": "Script",
-      "blurb": "Script is set of instructions beginning with a header. It can be read from file.",
       "uuid": "ad9b3663-1194-4f5b-bce7-ec1e35042b2a"
     },
     {
       "slug": "strings",
       "name": "String! type",
-      "blurb": "Strings are values of type string!. They usually represent textual data.",
       "uuid": "a936c324-9503-4acc-968f-ab18b8092ed0"
     },
     {
       "slug": "functions",
       "name": "Functions",
-      "blurb": "Functions usually do something useful. And they usually return a value.",
       "uuid": "af09604a-bbfc-460f-8b78-5850abf16bea"
     }
   ],
@@ -97,7 +92,11 @@
         "name": "Hello World",
         "status": "wip",
         "uuid": "1d2e9dab-d85e-4b30-b414-1ebd969475ad",
-        "practices": ["basics", "script-header", "strings"],
+        "practices": [
+          "basics",
+          "script-header",
+          "strings"
+        ],
         "prerequisites": [],
         "difficulty": 1
       }


### PR DESCRIPTION
_TL;DR; Add authors/contributors to a new `concepts/<slug>/.meta/config.json` to Concepts in the same way you have for Concept Exercises._

---

To properly attribute authorship/contributorship for an individual concept, each concept will have its own `.meta/config.json` file with `authors` and `contributors` keys like those for concept and practice exercises. We're also moving the concept's blurb from the track's `config.json` to the `.meta/config.json` file, also similar to concept and practice exercises.

See https://github.com/exercism/docs/pull/96/files for the update to the specification.

This PR adds a `.meta/config.json` file for all concepts found in the track's `config.json` file containing:

- A `blurb` key, which value is copied from the `config.json` file and subsequently removed from the `config.json` file
- An `authors` key, the value of which is an empty array  
- A `contributors` key, the value of which is an empty array

## Maintainers TODO list

These are the things you, the maintainers, should do:

- [ ] Add the authors
- [ ] Add the contributors (if any)

**For clarity, authors should be the people who originally created the concept documents on this track. Contributors should be people who have substantially contributed to the concept documents. PRs for typos or multiple-concept PRs do not automatically mean someone should be considered a contributor to that concept. Those non-concept-specific contributions will get recognition through Exercism's reputation system in v3.**

You can either update this PR by pushing a new commit to this PR, or merge this and do a follow-up PR later. The former has the disadvantage that once we've added linting rules to `configlet` for the concept `.meta/config.json` file, the configlet CI check will start failing. 

## Tracking

https://github.com/exercism/v3-launch/issues/27
