### PR TITLE
Add icons for key features

### DIFF
--- a/config.json
+++ b/config.json
@@ -80,32 +80,32 @@
     {
       "title": "Full-stack",
       "content": "Red can be used to create a device driver as well as a GUI application.",
-      "icon": "features-oop"
+      "icon": "general-purpose"
     },
     {
       "title": "Lightweight",
       "content": "Entire toolchain is about 1.5 MB download, single executable. Low memory footprint.",
-      "icon": "features-oop"
+      "icon": "small"
     },
     {
       "title": "Code is data",
       "content": "Red is its own meta-language and own data-format. Program can operate on it's own code.",
-      "icon": "features-oop"
+      "icon": "interop"
     },
     {
       "title": "DSL",
       "content": "It's easy to create Domain Specific Languages, dialects and parsers.",
-      "icon": "features-oop"
+      "icon": "stable"
     },
     {
       "title": "GUI",
       "content": "It's simple as: view [b: base 100x100 button {Draw circle} [b/draw: [pen red circle 50x50 50]]]",
-      "icon": "features-oop"
+      "icon": "interactive"
     },
     {
       "title": "Reactive",
       "content": "Objects can be linked by reactions to reduce size and complexity of program.",
-      "icon": "features-oop"
+      "icon": "extensible"
     }
   ],
   "exercises": {


### PR DESCRIPTION
The icons for key features are now available, and `configlet lint` now requires that each key feature has a valid `icon` value.

This PR sets an initial icon for each key feature - feel free to change them however you want. You can see the list of available icons [here](https://github.com/exercism/docs/issues/189). Note that an icon can be used regardless of its name.

With the initial state of this PR, the key features look something like the below.

---

![general-purpose](https://raw.githubusercontent.com/exercism/website-icons/main/key-features/general-purpose.svg) Full-stack
Red can be used to create a device driver as well as a GUI application.

![small](https://raw.githubusercontent.com/exercism/website-icons/main/key-features/small.svg) Lightweight
Entire toolchain is about 1.5 MB download, single executable. Low memory footprint.

![interop](https://raw.githubusercontent.com/exercism/website-icons/main/key-features/interop.svg) Code is data
Red is its own meta-language and own data-format. Program can operate on it's own code.

![stable](https://raw.githubusercontent.com/exercism/website-icons/main/key-features/stable.svg) DSL
It's easy to create Domain Specific Languages, dialects and parsers.

![interactive](https://raw.githubusercontent.com/exercism/website-icons/main/key-features/interactive.svg) GUI
It's simple as: view [b: base 100x100 button {Draw circle} [b/draw: [pen red circle 50x50 50]]]

![extensible](https://raw.githubusercontent.com/exercism/website-icons/main/key-features/extensible.svg) Reactive
Objects can be linked by reactions to reduce size and complexity of program.
