### PR TITLE
Add CI to verify exercises against example implementation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,64 +1,18 @@
-# This workflow will do a clean install of the dependencies and run tests across different versions
-#
-# Replace <track> with the track name
-# Replace <image-name> with an image to run the jobs on
-# Replace <action to setup tooling> with a github action to setup tooling on the image
-# Replace <install dependencies> with a cli command to install the dependencies
-# Replace <code-extensions> with file extensions that should trigger the workflow
-#
-# Find Github Actions to setup tooling here:
-# - https://github.com/actions/?q=setup&type=&language=
-# - https://github.com/actions/starter-workflows/tree/main/ci
-# - https://github.com/marketplace?type=actions&query=setup
-#
-# Requires scripts:
-# - scripts/ci-check
-# - scripts/ci
-
-name: <track> / main
+name: Test
 
 on:
   push:
     branches: [main]
+  pull_request:
   workflow_dispatch:
 
 jobs:
-  precheck:
-    runs-on: <image-name>
-
-    steps:
-      - uses: actions/checkout@v3
-      - name: Use <setup tooling>
-        uses: <action to setup tooling>
-        with:
-          # Here, use the LTS/stable version of the track's tooling, e.g.:
-          # node-version: 12.x
-
-      - name: Install project dependencies
-        run: <install dependencies>
-
-      - name: Run exercism/<track> ci pre-check (checks config, lint code) for all exercises
-        run: scripts/ci-check
-
   ci:
-    runs-on: <image-name>
-
-    strategy:
-      matrix:
-        # Here, add all SUPPORTED versions only, e.g.:
-        # version: [10.x, 12.x, 14.x]
-        # Optionally, add more matrix variables, such as os or arch
+    runs-on: ubuntu-20.04
 
     steps:
-      - uses: actions/checkout@v3
-      - name: Use <setup tooling> ${{ matrix.version }}
-        uses: <action to setup tooling>
-        with:
-          # Use the ${{ matrix.x }} format to inject variables into commands
-          # node-version: ${{ matrix.version }}
+      - name: Checkout repository
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
 
-      - name: Install project dependencies
-        run: <install dependencies>
-
-      - name: Run exercism/<track> ci (runs tests) for all exercises
-        run: scripts/ci
+      - name: Run tests for all exercises
+        run: bin/test

--- a/bin/test
+++ b/bin/test
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+
+# Test if the example/exemplar solution of each 
+# Practice/Concept Exercise passes the exercise's tests.
+
+# Example:
+# ./bin/test
+
+set -eo pipefail
+
+docker pull exercism/red-test-runner
+
+exit_code=0
+
+function run_test_runner() {
+    local dir=$1
+    local slug=$2
+
+    docker run \
+        --rm \
+        --network none \
+        --mount type=bind,src="${dir}",dst=/solution \
+        --mount type=bind,src="${dir}",dst=/output \
+        --tmpfs /tmp:rw \
+        exercism/red-test-runner "${slug}" "/solution" "/output"
+}
+
+function verify_exercise() {
+    local dir=$(realpath $1)
+    local slug=$(basename "${dir}")
+    local implementation_file_key=$2    
+    local implementation_file="${dir}/.meta/example.red"
+    local stub_file="${dir}/${slug}.red"
+    local stub_backup_file="${stub_file}.bak"
+    local results_file="${dir}/results.json"
+
+    cp "${stub_file}" "${stub_backup_file}"
+    cp "${implementation_file}" "${stub_file}"
+
+    run_test_runner "${dir}" "${slug}"
+
+    if [[ $(jq -r '.status' "${results_file}") != "pass" ]]; then
+        echo "${slug}: ${implementation_file_key} solution did not pass the tests"
+        exit_code=1
+    fi
+
+    mv "${stub_backup_file}" "${stub_file}"
+    rm -f "${results_file}"
+}
+
+# Verify the Concept Exercises
+for concept_exercise_dir in ./exercises/concept/*/; do
+    if [ -d $concept_exercise_dir ]; then
+        echo "Checking $(basename "${concept_exercise_dir}") exercise..."
+        verify_exercise $concept_exercise_dir "exemplar"
+    fi
+done
+
+# Verify the Practice Exercises
+for practice_exercise_dir in ./exercises/practice/*/; do
+    if [ -d $practice_exercise_dir ]; then
+        echo "Checking $(basename "${practice_exercise_dir}") exercise..."
+        verify_exercise $practice_exercise_dir "example"
+    fi
+done
+
+exit ${exit_code}

--- a/bin/test
+++ b/bin/test
@@ -41,6 +41,8 @@ function verify_exercise() {
 
     if [[ $(jq -r '.status' "${results_file}") != "pass" ]]; then
         echo "${slug}: ${implementation_file_key} solution did not pass the tests"
+        cat "${results_file}"
+        echo ""
         exit_code=1
     fi
 

--- a/exercises/practice/pov/pov-test.red
+++ b/exercises/practice/pov/pov-test.red
@@ -5,8 +5,8 @@ Red [
 
 #include %testlib.red
 
-; test-init/limit %pov.red 1
-test-init/limit %.meta/example.red 15						; test example solution
+test-init/limit %pov.red 1
+; test-init/limit %.meta/example.red 15						; test example solution
 
 canonical-cases: [#(
     description: {Results in the same tree if the input tree is a singleton}

--- a/exercises/practice/sgf-parsing/sgf-parsing.red
+++ b/exercises/practice/sgf-parsing/sgf-parsing.red
@@ -6,6 +6,6 @@ Red [
 parse-sgf: function [
 	encoded
 ] [
-	do make error! "You need to implement this function."
+	cause-error 'user 'message "You need to implement parse-sgf function."
 ]
 

--- a/exercises/practice/sgf-parsing/testlib.red
+++ b/exercises/practice/sgf-parsing/testlib.red
@@ -5,18 +5,22 @@ Red [
 
 
 context [
-	tested: ignore-after: test-file: results: output: none
+	tested: 0
+	ignore-after: none
+	test-file: none
+	results: none
+	output: copy ""
 	
 	set 'test-init function [
 		file	[file!]
 		/limit
 			ia	[integer!]
 	] [
-		self/tested: 0
-		self/ignore-after: either limit [ia] [none]
 		self/test-file: file
 		self/results: copy []
-		self/output: copy ""
+		if limit [
+			self/ignore-after: ia
+		]
 	]
 
 	sandbox!: context [
@@ -148,11 +152,7 @@ context [
 								newline
 								result/output
 							]]
-						error	[rejoin [
-								newline
-								result/output
-								form result/actual
-							]]
+						error	[form result/actual]
 						ignored	["(ignored)"]
 					]
 				]


### PR DESCRIPTION
@loziniak The PR currently fails. This is due to the test runner's output not being conform the specification. 
Here is some sample output of the test runner:

```
{"version":2,"status":"ignored","message":null,"tests":[{"name":"Convert an array to linked list, and then from linked list back to array","status":"pass","message":"✓","output":"","test_code":"solution = [3 6 1]"},{"name":"Convert from array, reverse the list, and covert to array","status":"ignored","message":"✓","output":null,"test_code":"solution = none"}]}
```

The problem is that the general and test `status` fields are set to `ignored`, which is not one of the three allowed values (`pass`/`fail`/`error`): https://exercism.org/docs/building/tooling/test-runners/interface
I assume this is because, well, the tests are ignored. The solution is for the test runner to un-ignore the tests before it runs them. Let me know if you have any questions.

Closes https://github.com/exercism/red/issues/48