### PR TITLE
reverse-string: fix example solution

### DIFF
--- a/exercises/practice/reverse-string/.meta/example.red
+++ b/exercises/practice/reverse-string/.meta/example.red
@@ -3,10 +3,12 @@ Red [
 	author: "loziniak"
 ]
 
-reverse-string: function [
+red-reverse: :system/words/reverse
+
+reverse: function [
 	"Reverses a string"
 	input [string!] "String to reverse"
 	return: [string!]
 ] [
-	reverse input
+	red-reverse input
 ]


### PR DESCRIPTION
As spotted by @ryanplusplus in #91 , example solution was broken, and only reason it passed CI/CD was, that a built-in `reverse` action was being tested instead of the solution.