### PR TITLE
Sync tests.toml with problem-specifications

### DIFF
--- a/exercises/practice/darts/.meta/tests.toml
+++ b/exercises/practice/darts/.meta/tests.toml
@@ -1,41 +1,49 @@
-[canonical-tests]
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
 
-# Missed target
-"9033f731-0a3a-4d9c-b1c0-34a1c8362afb" = true
+[9033f731-0a3a-4d9c-b1c0-34a1c8362afb]
+description = "Missed target"
 
-# On the outer circle
-"4c9f6ff4-c489-45fd-be8a-1fcb08b4d0ba" = true
+[4c9f6ff4-c489-45fd-be8a-1fcb08b4d0ba]
+description = "On the outer circle"
 
-# On the middle circle
-"14378687-ee58-4c9b-a323-b089d5274be8" = true
+[14378687-ee58-4c9b-a323-b089d5274be8]
+description = "On the middle circle"
 
-# On the inner circle
-"849e2e63-85bd-4fed-bc3b-781ae962e2c9" = true
+[849e2e63-85bd-4fed-bc3b-781ae962e2c9]
+description = "On the inner circle"
 
-# Exactly on centre
-"1c5ffd9f-ea66-462f-9f06-a1303de5a226" = true
+[1c5ffd9f-ea66-462f-9f06-a1303de5a226]
+description = "Exactly on center"
 
-# Near the centre
-"b65abce3-a679-4550-8115-4b74bda06088" = true
+[b65abce3-a679-4550-8115-4b74bda06088]
+description = "Near the center"
 
-# Just within the inner circle
-"66c29c1d-44f5-40cf-9927-e09a1305b399" = true
+[66c29c1d-44f5-40cf-9927-e09a1305b399]
+description = "Just within the inner circle"
 
-# Just outside the inner circle
-"d1012f63-c97c-4394-b944-7beb3d0b141a" = true
+[d1012f63-c97c-4394-b944-7beb3d0b141a]
+description = "Just outside the inner circle"
 
-# Just within the middle circle
-"ab2b5666-b0b4-49c3-9b27-205e790ed945" = true
+[ab2b5666-b0b4-49c3-9b27-205e790ed945]
+description = "Just within the middle circle"
 
-# Just outside the middle circle
-"70f1424e-d690-4860-8caf-9740a52c0161" = true
+[70f1424e-d690-4860-8caf-9740a52c0161]
+description = "Just outside the middle circle"
 
-# Just within the outer circle
-"a7dbf8db-419c-4712-8a7f-67602b69b293" = true
+[a7dbf8db-419c-4712-8a7f-67602b69b293]
+description = "Just within the outer circle"
 
-# Just outside the outer circle
-"e0f39315-9f9a-4546-96e4-a9475b885aa7" = true
+[e0f39315-9f9a-4546-96e4-a9475b885aa7]
+description = "Just outside the outer circle"
 
-# Asymmetric position between the inner and middle circles
-"045d7d18-d863-4229-818e-b50828c75d19" = true
-
+[045d7d18-d863-4229-818e-b50828c75d19]
+description = "Asymmetric position between the inner and middle circles"

--- a/exercises/practice/hello-world/.meta/tests.toml
+++ b/exercises/practice/hello-world/.meta/tests.toml
@@ -1,5 +1,13 @@
-[canonical-tests]
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
 
-# Say Hi!
-"af9ffe10-dc13-42d8-a742-e7bdafac449d" = true
-
+[af9ffe10-dc13-42d8-a742-e7bdafac449d]
+description = "Say Hi!"

--- a/exercises/practice/high-scores/.meta/tests.toml
+++ b/exercises/practice/high-scores/.meta/tests.toml
@@ -1,32 +1,40 @@
-[canonical-tests]
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
 
-# List of scores
-"1035eb93-2208-4c22-bab8-fef06769a73c" = true
+[1035eb93-2208-4c22-bab8-fef06769a73c]
+description = "List of scores"
 
-# Latest score
-"6aa5dbf5-78fa-4375-b22c-ffaa989732d2" = true
+[6aa5dbf5-78fa-4375-b22c-ffaa989732d2]
+description = "Latest score"
 
-# Personal best
-"b661a2e1-aebf-4f50-9139-0fb817dd12c6" = true
+[b661a2e1-aebf-4f50-9139-0fb817dd12c6]
+description = "Personal best"
 
-# Personal top three from a list of scores
-"3d996a97-c81c-4642-9afc-80b80dc14015" = true
+[3d996a97-c81c-4642-9afc-80b80dc14015]
+description = "Top 3 scores -> Personal top three from a list of scores"
 
-# Personal top highest to lowest
-"1084ecb5-3eb4-46fe-a816-e40331a4e83a" = true
+[1084ecb5-3eb4-46fe-a816-e40331a4e83a]
+description = "Top 3 scores -> Personal top highest to lowest"
 
-# Personal top when there is a tie
-"e6465b6b-5a11-4936-bfe3-35241c4f4f16" = true
+[e6465b6b-5a11-4936-bfe3-35241c4f4f16]
+description = "Top 3 scores -> Personal top when there is a tie"
 
-# Personal top when there are less than 3
-"f73b02af-c8fd-41c9-91b9-c86eaa86bce2" = true
+[f73b02af-c8fd-41c9-91b9-c86eaa86bce2]
+description = "Top 3 scores -> Personal top when there are less than 3"
 
-# Personal top when there is only one
-"16608eae-f60f-4a88-800e-aabce5df2865" = true
+[16608eae-f60f-4a88-800e-aabce5df2865]
+description = "Top 3 scores -> Personal top when there is only one"
 
-# Latest score after personal top scores
-"2df075f9-fec9-4756-8f40-98c52a11504f" = true
+[2df075f9-fec9-4756-8f40-98c52a11504f]
+description = "Top 3 scores -> Latest score after personal top scores"
 
-# Scores after personal top scores
-"809c4058-7eb1-4206-b01e-79238b9b71bc" = true
-
+[809c4058-7eb1-4206-b01e-79238b9b71bc]
+description = "Top 3 scores -> Scores after personal top scores"

--- a/exercises/practice/raindrops/.meta/tests.toml
+++ b/exercises/practice/raindrops/.meta/tests.toml
@@ -1,56 +1,64 @@
-[canonical-tests]
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
 
-# the sound for 1 is 1
-"1575d549-e502-46d4-a8e1-6b7bec6123d8" = true
+[1575d549-e502-46d4-a8e1-6b7bec6123d8]
+description = "the sound for 1 is 1"
 
-# the sound for 3 is Pling
-"1f51a9f9-4895-4539-b182-d7b0a5ab2913" = true
+[1f51a9f9-4895-4539-b182-d7b0a5ab2913]
+description = "the sound for 3 is Pling"
 
-# the sound for 5 is Plang
-"2d9bfae5-2b21-4bcd-9629-c8c0e388f3e0" = true
+[2d9bfae5-2b21-4bcd-9629-c8c0e388f3e0]
+description = "the sound for 5 is Plang"
 
-# the sound for 7 is Plong
-"d7e60daa-32ef-4c23-b688-2abff46c4806" = true
+[d7e60daa-32ef-4c23-b688-2abff46c4806]
+description = "the sound for 7 is Plong"
 
-# the sound for 6 is Pling as it has a factor 3
-"6bb4947b-a724-430c-923f-f0dc3d62e56a" = true
+[6bb4947b-a724-430c-923f-f0dc3d62e56a]
+description = "the sound for 6 is Pling as it has a factor 3"
 
-# 2 to the power 3 does not make a raindrop sound as 3 is the exponent not the base
-"ce51e0e8-d9d4-446d-9949-96eac4458c2d" = true
+[ce51e0e8-d9d4-446d-9949-96eac4458c2d]
+description = "2 to the power 3 does not make a raindrop sound as 3 is the exponent not the base"
 
-# the sound for 9 is Pling as it has a factor 3
-"0dd66175-e3e2-47fc-8750-d01739856671" = true
+[0dd66175-e3e2-47fc-8750-d01739856671]
+description = "the sound for 9 is Pling as it has a factor 3"
 
-# the sound for 10 is Plang as it has a factor 5
-"022c44d3-2182-4471-95d7-c575af225c96" = true
+[022c44d3-2182-4471-95d7-c575af225c96]
+description = "the sound for 10 is Plang as it has a factor 5"
 
-# the sound for 14 is Plong as it has a factor of 7
-"37ab74db-fed3-40ff-b7b9-04acdfea8edf" = true
+[37ab74db-fed3-40ff-b7b9-04acdfea8edf]
+description = "the sound for 14 is Plong as it has a factor of 7"
 
-# the sound for 15 is PlingPlang as it has factors 3 and 5
-"31f92999-6afb-40ee-9aa4-6d15e3334d0f" = true
+[31f92999-6afb-40ee-9aa4-6d15e3334d0f]
+description = "the sound for 15 is PlingPlang as it has factors 3 and 5"
 
-# the sound for 21 is PlingPlong as it has factors 3 and 7
-"ff9bb95d-6361-4602-be2c-653fe5239b54" = true
+[ff9bb95d-6361-4602-be2c-653fe5239b54]
+description = "the sound for 21 is PlingPlong as it has factors 3 and 7"
 
-# the sound for 25 is Plang as it has a factor 5
-"d2e75317-b72e-40ab-8a64-6734a21dece1" = true
+[d2e75317-b72e-40ab-8a64-6734a21dece1]
+description = "the sound for 25 is Plang as it has a factor 5"
 
-# the sound for 27 is Pling as it has a factor 3
-"a09c4c58-c662-4e32-97fe-f1501ef7125c" = true
+[a09c4c58-c662-4e32-97fe-f1501ef7125c]
+description = "the sound for 27 is Pling as it has a factor 3"
 
-# the sound for 35 is PlangPlong as it has factors 5 and 7
-"bdf061de-8564-4899-a843-14b48b722789" = true
+[bdf061de-8564-4899-a843-14b48b722789]
+description = "the sound for 35 is PlangPlong as it has factors 5 and 7"
 
-# the sound for 49 is Plong as it has a factor 7
-"c4680bee-69ba-439d-99b5-70c5fd1a7a83" = true
+[c4680bee-69ba-439d-99b5-70c5fd1a7a83]
+description = "the sound for 49 is Plong as it has a factor 7"
 
-# the sound for 52 is 52
-"17f2bc9a-b65a-4d23-8ccd-266e8c271444" = true
+[17f2bc9a-b65a-4d23-8ccd-266e8c271444]
+description = "the sound for 52 is 52"
 
-# the sound for 105 is PlingPlangPlong as it has factors 3, 5 and 7
-"e46677ed-ff1a-419f-a740-5c713d2830e4" = true
+[e46677ed-ff1a-419f-a740-5c713d2830e4]
+description = "the sound for 105 is PlingPlangPlong as it has factors 3, 5 and 7"
 
-# the sound for 3125 is Plang as it has a factor 5
-"13c6837a-0fcd-4b86-a0eb-20572f7deb0b" = true
-
+[13c6837a-0fcd-4b86-a0eb-20572f7deb0b]
+description = "the sound for 3125 is Plang as it has a factor 5"

--- a/exercises/practice/resistor-color/.meta/tests.toml
+++ b/exercises/practice/resistor-color/.meta/tests.toml
@@ -1,14 +1,22 @@
-[canonical-tests]
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
 
-# Black
-"49eb31c5-10a8-4180-9f7f-fea632ab87ef" = true
+[49eb31c5-10a8-4180-9f7f-fea632ab87ef]
+description = "Color codes -> Black"
 
-# White
-"0a4df94b-92da-4579-a907-65040ce0b3fc" = true
+[0a4df94b-92da-4579-a907-65040ce0b3fc]
+description = "Color codes -> White"
 
-# Orange
-"5f81608d-f36f-4190-8084-f45116b6f380" = true
+[5f81608d-f36f-4190-8084-f45116b6f380]
+description = "Color codes -> Orange"
 
-# Colors
-"581d68fa-f968-4be2-9f9d-880f2fb73cf7" = true
-
+[581d68fa-f968-4be2-9f9d-880f2fb73cf7]
+description = "Colors"

--- a/exercises/practice/reverse-string/.meta/tests.toml
+++ b/exercises/practice/reverse-string/.meta/tests.toml
@@ -1,19 +1,28 @@
-[canonical-tests]
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
 
-# an empty string
-"c3b7d806-dced-49ee-8543-933fd1719b1c" = true
+[c3b7d806-dced-49ee-8543-933fd1719b1c]
+description = "an empty string"
 
-# a word
-"01ebf55b-bebb-414e-9dec-06f7bb0bee3c" = true
+[01ebf55b-bebb-414e-9dec-06f7bb0bee3c]
+description = "a word"
 
-# a capitalized word
-"0f7c07e4-efd1-4aaa-a07a-90b49ce0b746" = true
+[0f7c07e4-efd1-4aaa-a07a-90b49ce0b746]
+description = "a capitalized word"
 
-# a sentence with punctuation
-"71854b9c-f200-4469-9f5c-1e8e5eff5614" = true
+[71854b9c-f200-4469-9f5c-1e8e5eff5614]
+description = "a sentence with punctuation"
 
-# a palindrome
-"1f8ed2f3-56f3-459b-8f3e-6d8d654a1f6c" = true
+[1f8ed2f3-56f3-459b-8f3e-6d8d654a1f6c]
+description = "a palindrome"
 
-# an even-sized word
-"b9e7dec1-c6df-40bd-9fa3-cd7ded010c4c" = true
+[b9e7dec1-c6df-40bd-9fa3-cd7ded010c4c]
+description = "an even-sized word"

--- a/exercises/practice/rotational-cipher/.meta/tests.toml
+++ b/exercises/practice/rotational-cipher/.meta/tests.toml
@@ -1,32 +1,40 @@
-[canonical-tests]
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
 
-# rotate a by 0, same output as input
-"74e58a38-e484-43f1-9466-877a7515e10f" = true
+[74e58a38-e484-43f1-9466-877a7515e10f]
+description = "rotate a by 0, same output as input"
 
-# rotate a by 1
-"7ee352c6-e6b0-4930-b903-d09943ecb8f5" = true
+[7ee352c6-e6b0-4930-b903-d09943ecb8f5]
+description = "rotate a by 1"
 
-# rotate a by 26, same output as input
-"edf0a733-4231-4594-a5ee-46a4009ad764" = true
+[edf0a733-4231-4594-a5ee-46a4009ad764]
+description = "rotate a by 26, same output as input"
 
-# rotate m by 13
-"e3e82cb9-2a5b-403f-9931-e43213879300" = true
+[e3e82cb9-2a5b-403f-9931-e43213879300]
+description = "rotate m by 13"
 
-# rotate n by 13 with wrap around alphabet
-"19f9eb78-e2ad-4da4-8fe3-9291d47c1709" = true
+[19f9eb78-e2ad-4da4-8fe3-9291d47c1709]
+description = "rotate n by 13 with wrap around alphabet"
 
-# rotate capital letters
-"a116aef4-225b-4da9-884f-e8023ca6408a" = true
+[a116aef4-225b-4da9-884f-e8023ca6408a]
+description = "rotate capital letters"
 
-# rotate spaces
-"71b541bb-819c-4dc6-a9c3-132ef9bb737b" = true
+[71b541bb-819c-4dc6-a9c3-132ef9bb737b]
+description = "rotate spaces"
 
-# rotate numbers
-"ef32601d-e9ef-4b29-b2b5-8971392282e6" = true
+[ef32601d-e9ef-4b29-b2b5-8971392282e6]
+description = "rotate numbers"
 
-# rotate punctuation
-"32dd74f6-db2b-41a6-b02c-82eb4f93e549" = true
+[32dd74f6-db2b-41a6-b02c-82eb4f93e549]
+description = "rotate punctuation"
 
-# rotate all letters
-"9fb93fe6-42b0-46e6-9ec1-0bf0a062d8c9" = true
-
+[9fb93fe6-42b0-46e6-9ec1-0bf0a062d8c9]
+description = "rotate all letters"

--- a/exercises/practice/space-age/.meta/tests.toml
+++ b/exercises/practice/space-age/.meta/tests.toml
@@ -1,26 +1,38 @@
-[canonical-tests]
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
 
-# age on Earth
-"84f609af-5a91-4d68-90a3-9e32d8a5cd34" = true
+[84f609af-5a91-4d68-90a3-9e32d8a5cd34]
+description = "age on Earth"
 
-# age on Mercury
-"ca20c4e9-6054-458c-9312-79679ffab40b" = true
+[ca20c4e9-6054-458c-9312-79679ffab40b]
+description = "age on Mercury"
 
-# age on Venus
-"502c6529-fd1b-41d3-8fab-65e03082b024" = true
+[502c6529-fd1b-41d3-8fab-65e03082b024]
+description = "age on Venus"
 
-# age on Mars
-"9ceadf5e-a0d5-4388-9d40-2c459227ceb8" = true
+[9ceadf5e-a0d5-4388-9d40-2c459227ceb8]
+description = "age on Mars"
 
-# age on Jupiter
-"42927dc3-fe5e-4f76-a5b5-f737fc19bcde" = true
+[42927dc3-fe5e-4f76-a5b5-f737fc19bcde]
+description = "age on Jupiter"
 
-# age on Saturn
-"8469b332-7837-4ada-b27c-00ee043ebcad" = true
+[8469b332-7837-4ada-b27c-00ee043ebcad]
+description = "age on Saturn"
 
-# age on Uranus
-"999354c1-76f8-4bb5-a672-f317b6436743" = true
+[999354c1-76f8-4bb5-a672-f317b6436743]
+description = "age on Uranus"
 
-# age on Neptune
-"80096d30-a0d4-4449-903e-a381178355d8" = true
+[80096d30-a0d4-4449-903e-a381178355d8]
+description = "age on Neptune"
 
+[57b96e2a-1178-40b7-b34d-f3c9c34e4bf4]
+description = "invalid planet causes error"
+include = false

--- a/exercises/practice/two-fer/.meta/tests.toml
+++ b/exercises/practice/two-fer/.meta/tests.toml
@@ -1,10 +1,19 @@
-[canonical-tests]
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
 
-# no name given
-"1cf3e15a-a3d7-4a87-aeb3-ba1b43bc8dce" = true
+[1cf3e15a-a3d7-4a87-aeb3-ba1b43bc8dce]
+description = "no name given"
 
-# a name given
-"b4c6dbb8-b4fb-42c2-bafd-10785abe7709" = true
+[b4c6dbb8-b4fb-42c2-bafd-10785abe7709]
+description = "a name given"
 
-# another name given
-"3549048d-1a6e-4653-9a79-b0bda163e8d5" = true
+[3549048d-1a6e-4653-9a79-b0bda163e8d5]
+description = "another name given"


### PR DESCRIPTION
I was running configlet sync to get the latest `leap` docs, and I noticed a lot of exercises are marked as missing tests simply because they don't have an updated tests.toml.  This PR updates a few. Others will need to be looked at more carefully to see what tests are already in the suite.