### PR TITLE
Remove Helpin' Red from LEARNING.md

### DIFF
--- a/docs/LEARNING.md
+++ b/docs/LEARNING.md
@@ -3,7 +3,7 @@
 As Red is not really a finished product (alpha-stage), everything changes fast. As a result, not many tutorials are available, and not much documentation in general. Red is just gaining its popularity. There are some pages worth mentioning though, that can help you with starting your journey.
 
 * [Learn X in Y minutes](https://learnxinyminutes.com/docs/red/) stands out as a pretty modern and not very elaborative resource.
-* [Helpin'Red](http://helpin.red/) is a really comprehensive step-by-step guide with lots of examples you can try by yourself.
+* [Red by Example](https://www.red-by-example.org/) contains an exhaustive list of Red words and concepts with examples.
 * [Getting Started With Red](http://redprogramming.com/Getting%20Started.html) is another classic.
 * As Red is based on Rebol, you can find a lot of useful info in [Learn REBOL](http://www.re-bol.com/rebol.html), by the same author.
 * If you get stuck, there is always someone ready to help you on [Red Gitter chat](https://gitter.im/red/help).


### PR DESCRIPTION
Helpin' Red's certificate expired 543 days ago so I'd like to remove it to be safe and substitute in Red By Example. It's unfortunate because Helpin' Red is a good resource otherwise. Thoughts?